### PR TITLE
(feat): Store "person"-qualifier; accountability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project loosely adheres to a date-based versioning scheme.
 
+## 2024-08-08
+
+### Changed
+
+* **Person qualifier!** Rather than setting the qualifier to `None` (and `null` in MongoDB) for persons, a new qualifier `person` is introduced.
+
+### Added
+
+* **`--whoami` flag required!** For the insert-subcommand, passing a personal identifier of the curator excercising the import is required; this will be stored in MongoDB in the `updatedBy`-field in the project collection 
+
 ## 2024-08-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ Run with `python cli.py insert --help` to get an overview for the required argum
 This command will read the provided Excel file, and sync the data into the specified collection in MongoDB.
 The `--dry-run`-flag can be used to test things out, it will not perform any insertion.
 
+Be sure to pass your personal identifier (e.g., initials) to the `--whoami` flag to set the correct responsibility in MongoDB.
+
 #### Example
 
 ``` shell
 $ python cli.py insert \
+    --whoami JaneDoe \
     --connection mongodb://root:example@mongo \
     --target projects_metadata_ubt_TEST.sample_project \
     -project-id aaa \
@@ -208,7 +211,7 @@ The `name`-key stores names of associated persons (or other actors, e.g., groups
     {
         "name": {
             "label": string|null,     // the raw name; **null if not present**
-            "qualifier": string|null  // an optional qualifier; **null if not present**
+            "qualifier": string       // an optional qualifier; **defaults to "person"**
         }
         "affl": Array<string>         // list of affiliations; **may be empty!**
         "role": string                // the assigned role; **may be empty!**

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,6 +41,7 @@ $ Excel2Json insert [OPTIONS] FILE
 
 **Options**:
 
+* `-w, --whoami TEXT`: Your initials; will be stored in the `updatedBy` field in MongoDB  [required]
 * `-c, --connection TEXT`: MongoDB connection string, format: 'mongodb://<user>:<pass>@<host>/'  [required]
 * `-t, --target TEXT`: The target collection to write data to, format: <database>.<collection>  [required]
 * `-p, --project-id TEXT`: The project ID  [required]

--- a/src/Excel2Json/Excel2Json.py
+++ b/src/Excel2Json/Excel2Json.py
@@ -334,7 +334,9 @@ class ExportJson(object):
         if pd.isna(data["name"]):
             return None
 
-        name = collection.Name(label=data["name"].strip(), qualifier=None)
+        # set the 'person'-qualifier as default; will be overwritten if another
+        # qualifier is found
+        name = collection.Name(label=data["name"].strip(), qualifier=Qualifiers.PERSON.value)
         role = collection.Role(name=name, affl=[], role="")
 
         if "role" in data and not pd.isna(data["role"]):

--- a/src/Excel2Json/ValueSync.py
+++ b/src/Excel2Json/ValueSync.py
@@ -15,6 +15,7 @@ from .types import dictionary, collection
 class Qualifiers(enum.Enum):
     INSTITUTION = "institution"
     GROUP = "group"
+    PERSON = "person"
 
 class ValueList(object):
     def __init__(self, auth_string: str | None, db_name: str, col_name: str, dev_list: str, client: MongoClient | None = None):
@@ -47,7 +48,7 @@ class ValueList(object):
     def handle_persons(coll: Iterable[collection.Role]) -> list[dictionary.PersonItem]:
         persons = defaultdict(set)
         for item in coll:
-            if item['name']['qualifier'] is not None:
+            if item['name']['qualifier'] is not Qualifiers.PERSON.value:
                 continue
 
             # touch the key so that we can add to the set provided by the default factory

--- a/src/Excel2Json/cli.py
+++ b/src/Excel2Json/cli.py
@@ -19,6 +19,14 @@ app = typer.Typer(help="A CLI wrapper for metadata management")
 @app.command()
 def insert(
     file: Annotated[Path, typer.Argument(help="The Excel file to ingest")],
+    whoami: Annotated[
+        str,
+        typer.Option(
+            "--whoami",
+            "-w",
+            help="Your initials; will be stored in the `updatedBy` field in MongoDB",
+        ),
+    ],
     connection: Annotated[
         str,
         typer.Option(
@@ -55,6 +63,7 @@ def insert(
     If --dry-run is passed, it will only perform the wrangling and not insert
     anything.
     """
+    assert len(whoami) > 0
     parts = target.split(".")
     assert len(parts) == 2
     db_name = parts[0]
@@ -82,7 +91,7 @@ def insert(
     for doc in track(data, "Setting metadata and inserting..."):
         doc["createdAt"] = datetime.now()
         doc["updatedAt"] = datetime.now()
-        doc["updatedBy"] = "JaneDoe"
+        doc["updatedBy"] = whoami
 
         if dry_run:
             continue

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -15,7 +15,7 @@ def test_roles_are_transformed_to_the_correct_schema():
             "out": {
                 "name": {
                     "label": "Doe, Jane",
-                    "qualifier": None,
+                    "qualifier": "person",
                 },
                 "affl": [],
                 "role": "Researcher",
@@ -27,7 +27,7 @@ def test_roles_are_transformed_to_the_correct_schema():
             "out": {
                 "name": {
                     "label": "Doe, Jane",
-                    "qualifier": None,
+                    "qualifier": "person",
                 },
                 "affl": ["ACME Corp."],
                 "role": "Researcher",
@@ -39,7 +39,7 @@ def test_roles_are_transformed_to_the_correct_schema():
             "out": {
                 "name": {
                     "label": "Doe, Jane",
-                    "qualifier": None,
+                    "qualifier": "person",
                 },
                 "affl": ["ACME Corp."],
                 "role": "Researcher",
@@ -53,7 +53,7 @@ def test_roles_are_transformed_to_the_correct_schema():
                 "role": "Researcher",
             },
             "out": {
-                "name": {"label": "Doe, Jane", "qualifier": None},
+                "name": {"label": "Doe, Jane", "qualifier": "person"},
                 "affl": ["ACME Corp.", "Giga Corp."],
                 "role": "Researcher",
             },

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -47,7 +47,7 @@ def test_persons_are_transformed():
             "desc": "Single person, no affiliation",
             "in": [
                 {
-                    "name": {"label": "Doe, Jane", "qualifier": None},
+                    "name": {"label": "Doe, Jane", "qualifier": "person"},
                     "affl": [],
                 }
             ],
@@ -57,7 +57,7 @@ def test_persons_are_transformed():
             "desc": "Single person, single affiliation",
             "in": [
                 {
-                    "name": {"label": "Doe, Jane", "qualifier": None},
+                    "name": {"label": "Doe, Jane", "qualifier": "person"},
                     "affl": ["IEEE"],
                 }
             ],
@@ -67,15 +67,15 @@ def test_persons_are_transformed():
             "desc": "Multiple distinct persons, mixed affiliations",
             "in": [
                 {
-                    "name": {"label": "Doe, Jane", "qualifier": None},
+                    "name": {"label": "Doe, Jane", "qualifier": "person"},
                     "affl": ["IEEE"],
                 },
                 {
-                    "name": {"label": "Doe, John", "qualifier": None},
+                    "name": {"label": "Doe, John", "qualifier": "person"},
                     "affl": ["ACME Corp."],
                 },
                 {
-                    "name": {"label": "Test, Tina", "qualifier": None},
+                    "name": {"label": "Test, Tina", "qualifier": "person"},
                     "affl": ["ACME Corp."],
                 },
             ],
@@ -89,15 +89,15 @@ def test_persons_are_transformed():
             "desc": "Multiple same persons with differing affiliations",
             "in": [
                 {
-                    "name": {"label": "Doe, Jane", "qualifier": None},
+                    "name": {"label": "Doe, Jane", "qualifier": "person"},
                     "affl": ["IEEE"],
                 },
                 {
-                    "name": {"label": "Doe, Jane", "qualifier": None},
+                    "name": {"label": "Doe, Jane", "qualifier": "person"},
                     "affl": ["ACME Corp."],
                 },
                 {
-                    "name": {"label": "Test, Tina", "qualifier": None},
+                    "name": {"label": "Test, Tina", "qualifier": "person"},
                     "affl": ["ACME Corp."],
                 },
             ],


### PR DESCRIPTION
Adds the `--whoami`-flag to assign the responsible curator to the `updatedBy` field in MongoDB.
Stores a new qualifier `person` if none is given, i.e., person is assumed the default.