### PR TITLE
(fix): Don't check modified_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project loosely adheres to a date-based versioning scheme.
 
+## 2024-08-20
+
+### Changed
+
+* [*BREAKING*] **Python version!** This package now requires at least Python 3.10, due to use of the `match-case` control flow expression.
+
+### Fixed
+
+* **Idempotent update for person-affiliations** If a person exists in the dev collection, and has the same affiliations as the incoming person, MongoDB won't actually perform an update. There was a check in the code that was throwing weird errors in this case.
+
 ## 2024-08-19
 
 ### Changed

--- a/src/Excel2Json/ValueSync.py
+++ b/src/Excel2Json/ValueSync.py
@@ -169,13 +169,10 @@ class ValueList(object):
                         # make sure to convert back to list
                         merged_affils = list(mongo_affils | project_affils)
                         # update based on retrieved ID
-                        result = self._update_col.update_one(
+                        self._update_col.update_one(
                             {"_id": t["_id"]}, {"$set": {"affiliation": merged_affils}}
                         )
-                        if result.modified_count == 0:
-                            self._printer.fail(
-                                f"Error while updating item with ID {t['_id']}"
-                            )
+
                         # delete the current insertable, so that we can still
                         # use `insert_many` for the remaining items
                         del insert[i]
@@ -194,7 +191,15 @@ class ValueList(object):
         return True
 
 
-def compare_dicts(d1, d2):
+def compare_dicts(new, existing):
+    local_d1 = new.copy()
+    local_d2 = existing.copy()
+
+    if "_id" in local_d1:
+        del local_d1["_id"]
+    if "_id" in local_d2:
+        del local_d2["_id"]
+
     return "\n" + "\n".join(
-        difflib.ndiff(pprint.pformat(d1).splitlines(), pprint.pformat(d2).splitlines())
+        difflib.ndiff(pprint.pformat(local_d1).splitlines(), pprint.pformat(local_d2).splitlines())
     )


### PR DESCRIPTION
If a person exists in `dev` with the same affiliations as the incoming person, `modified_count` will be 0 - no updated had to happen, nothing to modify. Probably it is safe in this case to omit the check.