### PR TITLE
Don't delete items while we're iterating

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dev-dependencies = [
 
 [tool.rye.scripts]
 requirements = "sed '/^-e/d; /^#/d; /^$/d' requirements-dev.lock"
+lint = { chain = ["lint:black", "lint:flake8"] }
+"lint:flake8" = "flake8 src --count --select=E9,F63,F7,F82 --max-complexity=10 --max-line-length=127 --show-source --statistics"
+"lint:black" = "black --check src"
+analyze = "mypy src"
+cover = { chain = ["coverage:run", "coverage:html"] }
+"coverage:html" = "coverage html"
+"coverage:run" = "coverage run -m pytest -vv --cache-clear"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/Excel2Json/ValueSync.py
+++ b/src/Excel2Json/ValueSync.py
@@ -161,7 +161,7 @@ class ValueList(object):
                 test = self._update_col.find({"name": item["name"]})
                 if test is not None:
                     for t in test:
-                        self._printer.info(f"Existing person found: {t['name']}")
+                        self._printer.info("Existing person found:", t["name"])
                         print(compare_dicts(item, t))
                         # update the item with the set-union of affiliations
                         mongo_affils = set(t["affiliation"])
@@ -175,19 +175,30 @@ class ValueList(object):
 
                         # delete the current insertable, so that we can still
                         # use `insert_many` for the remaining items
-                        del insert[i]
+                        insert[i] = {}
 
+        insert = [item for item in insert if len(item) != 0]
         if len(insert) == 0:
-            self._printer.good("Successfully Synchronised!")
+            self._printer.good(
+                "Successfully Synchronised!",
+                "No items to insert, but no news is good news.",
+            )
             return True
 
         insert_all_result = self._update_col.insert_many(insert)
 
         if len(insert_all_result.inserted_ids) != len(insert):
-            self._printer.fail("Not all requested documents were inserted!")
+            self._printer.fail(
+                "Not all requested documents were inserted!",
+                f"You requested {len(insert)} objects, but I only inserted {len(insert_all_result.inserted_ids)}.",
+            )
+
             return False
 
-        self._printer.good("Successfully Synchronised!")
+        self._printer.good(
+            "Successfully Synchronised!",
+            f"Inserted {len(insert_all_result.inserted_ids)} objects",
+        )
         return True
 
 
@@ -201,5 +212,7 @@ def compare_dicts(new, existing):
         del local_d2["_id"]
 
     return "\n" + "\n".join(
-        difflib.ndiff(pprint.pformat(local_d1).splitlines(), pprint.pformat(local_d2).splitlines())
+        difflib.ndiff(
+            pprint.pformat(local_d1).splitlines(), pprint.pformat(local_d2).splitlines()
+        )
     )

--- a/src/Excel2Json/__main__.py
+++ b/src/Excel2Json/__main__.py
@@ -1,2 +1,3 @@
 from .cli import app
+
 app()

--- a/src/Excel2Json/types/dictionary.py
+++ b/src/Excel2Json/types/dictionary.py
@@ -1,4 +1,3 @@
-
 from typing import TypedDict
 
 


### PR DESCRIPTION
Fixes the issue of syncing persons, where two or more persons already exist in the dev dictionary, and the same persons appear in the incoming list. Due to foolish handling of list items, the loop would skip over important items, causing duplicates.